### PR TITLE
Omit ClientSettings import/export from entry module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,9 @@
  * @packageDocumentation
  */
 import init from "./init"
-import { ClientSettings } from "./@types"
 import ClientSettingsBuilder from "./util/clientSettingsBuilder"
 import Provider from "./lib/providerBase"
 import { Test } from "./lib/test"
 import Fetch from "./lib/fetch"
 
-export { init, ClientSettings, ClientSettingsBuilder, Provider, Test, Fetch }
+export { init, ClientSettingsBuilder, Provider, Test, Fetch }


### PR DESCRIPTION
It's still unclear why, but the ClientSettings import/export here causes
a problem in `parcel build` with the --experimental-scope-hoisting flag.

Some relevant Github issues:

* https://github.com/parcel-bundler/parcel/issues/2566

* https://github.com/parcel-bundler/parcel/issues/1540

This PR is to apply this "patch" to the main-with-cbsi-patches branch that lives only in the CBSi fork of the openinsights repo, and which Doppler.js targets. 